### PR TITLE
add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+from setuptools import setup, find_packages
+
+setup(
+    name="sock",
+    version="0.3.0",
+    description="Small scripts to simplify network communication",
+    long_description=open('README.md').read(),
+    license="MIT",
+    author="Alexey Hellman",
+    author_email="hellman1908@gmail.com",
+    url="https://github.com/hellman/sock",
+    packages=find_packages(),
+    py_modules=['sock'],
+    test_suite="test_sock.TestParseAddr",
+)


### PR DESCRIPTION
This patch enables `python setup.py install` and `python setup.py test` in `sock`. It will be required that following the version number and revising it in the `setup.py` file.
